### PR TITLE
Revert excluded_paths glob, bump to 1.1.1

### DIFF
--- a/pkr/utils.py
+++ b/pkr/utils.py
@@ -200,9 +200,8 @@ class TemplateEngine(object):
                           excluded_paths, gen_template)
         elif path.is_file():
             # Direct match for excluded paths
-            for glob_pattern in excluded_paths:
-                if path.match(glob_pattern):
-                    return
+            if path in excluded_paths:
+                return
             if path != origin:
                 # path = /pkr/src/backend/api/__init__.py
                 abs_path = path.relative_to(origin)

--- a/pkr/version.py
+++ b/pkr/version.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 # Copyright© 1986-2019 Altair Engineering Inc.
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"


### PR DESCRIPTION
Revert glob last update for excluded_paths, as it breaks with
`TypeError: 'PosixPath' object does not support indexing`
and is not needed since globs are already handled [here](https://github.com/altairengineering/pkr/blob/4d838811623e44a4ab38f7a11de8a211b88f1023/pkr/utils.py#L190)