### PR TITLE
Fix issue when printing to stdout with add_return

### DIFF
--- a/pkr/cli/log.py
+++ b/pkr/cli/log.py
@@ -14,7 +14,7 @@ def set_debug(debug=False):
 def write(msg, add_return=True):
     """Print the `msg` to the stdout"""
     if add_return:
-        msg += '\n'
+        msg = str(msg) + '\n'
     sys.stdout.write(msg)
     sys.stdout.flush()
 


### PR DESCRIPTION
Fix issue when printing with add_return messages which are not of type str (e.g. printing fails when msg is of type HTTPError)