### PR TITLE
k8s: more helm like usage

### DIFF
--- a/pkr/cli/parser.py
+++ b/pkr/cli/parser.py
@@ -134,9 +134,10 @@ def get_parser():
     # Start
     start_parser = sub_p.add_parser('start', help='Start pkr')
     add_service_argument(start_parser)
-
+    start_parser.add_argument(
+        '-y', '--yes', action='store_true', help="Answer yes to questions")
     start_parser.set_defaults(
-        func=lambda a: Kard.load_current().docker_cli.start(a.services))
+        func=lambda a: Kard.load_current().docker_cli.start(a.services, a.yes))
 
     # Up parser
     up_parser = sub_p.add_parser(

--- a/pkr/driver/base.py
+++ b/pkr/driver/base.py
@@ -253,7 +253,7 @@ class Pkr(object):
             write(error_msg)
             raise ImagePullError(error_msg)
 
-    def start(self, services):
+    def start(self, services, yes):
         """Starts services
 
         Args:

--- a/pkr/driver/docker_compose.py
+++ b/pkr/driver/docker_compose.py
@@ -181,7 +181,7 @@ class ComposePkr(Pkr):
         super(ComposePkr, self).build_images(
             [s for s in services if req_build(s)], tag, verbose, logfile)
 
-    def start(self, services=None):
+    def start(self, services=None, yes=False):
         self._call_compose('up', '-d', *(services or ()))
 
     def cmd_up(self, services=None, verbose=False, build_log=None):

--- a/pkr/driver/k8s.py
+++ b/pkr/driver/k8s.py
@@ -94,7 +94,7 @@ class KubernetesPkr(Pkr):
         def format_htpasswd(username, password):
             ht = HtpasswdFile()
             ht.set_password(username, password)
-            return str(ht.to_string().rstrip())
+            return ht.to_string().rstrip().decode('utf-8')
 
         data = {
             'kard_file_content': read_kard_file,

--- a/pkr/driver/k8s.py
+++ b/pkr/driver/k8s.py
@@ -2,9 +2,14 @@
 # Copyright© 1986-2018 Altair Engineering Inc.
 
 """Pkr functions for handling the life cycle with k8s"""
+import base64
 import os
 import shlex
 import subprocess
+import sys
+import yaml
+import zlib
+from tempfile import NamedTemporaryFile
 from time import sleep
 
 from kubernetes import client, config
@@ -13,6 +18,15 @@ from passlib.apache import HtpasswdFile
 from .base import DOCKER_SOCK, AbstractDriver, Pkr
 from ..cli.log import write
 from ..utils import get_pkr_path, ensure_definition_matches, merge
+
+CONFIGMAP = {
+    'apiVersion': 'v1',
+    'kind': 'ConfigMap',
+    'metadata': {
+        'namespace': 'kube-system',
+    },
+    'data': {},
+}
 
 
 class Driver(AbstractDriver):
@@ -100,19 +114,63 @@ class KubernetesPkr(Pkr):
                                 excluded_paths=[],
                                 gen_template=True)
 
-    def run_cmd(self, command):
+    def run_cmd(self, command, silent=False):
+        kwargs = {}
+        if silent:
+            kwargs['stdout'] = subprocess.PIPE
+            kwargs['stderr'] = subprocess.PIPE
         proc = subprocess.Popen(
             shlex.split(command),
             env=self.env,
-            close_fds=True
+            close_fds=True,
+            **kwargs
         )
         stdout, stderr = proc.communicate()
 
         return stdout or '', stderr or ''
 
-    def run_kubectl(self, cmd):
+    def run_kubectl(self, cmd, silent=False):
         """Run kubectl tool with the provided command"""
-        return self.run_cmd('kubectl {}'.format(cmd))
+        return self.run_cmd('kubectl {}'.format(cmd), silent)
+
+    def new_configmap(self):
+        """
+        Provide a fresh configmap
+        """
+        cm = CONFIGMAP.copy()
+        cm['metadata']['name'] = "pkr-{}".format(self.kard.name)
+        return cm
+
+    def get_configmap(self):
+        """
+        Retrieve previously stored content for this kard
+        """
+        out, err = self.run_kubectl(
+            'get cm -n kube-system pkr-{} -o yaml'.format(self.kard.name),
+            silent=True)
+        if err != "":
+            if b"NotFound" in err:
+                return {}
+            raise Exception("Failed to get configmap pkr-{} with : {}".format(
+                self.kard.name, err))
+        out_hash = {}
+        for key, value in yaml.load(out).get('data', {}).items():
+            out_hash[key] = zlib.decompress(
+                base64.b64decode(value)).decode('utf-8')
+        return out_hash
+
+    def write_configmap(self, cm):
+        """
+        Write a configmap for this kard with deployed content
+        cm: {"pkr_template_name": "pkr_template_content", ...}
+        """
+        cm_compressed = self.new_configmap()
+        for key in cm:
+            cm_compressed['data'][key] = base64.b64encode(
+                zlib.compress(cm[key].encode('utf-8')))
+        with NamedTemporaryFile() as f:
+            f.write(yaml.dump(cm_compressed).encode('utf-8'))
+            self.run_kubectl('apply -f {}'.format(f.name))
 
     def start(self, services=None):
         """Starts services
@@ -122,17 +180,63 @@ class KubernetesPkr(Pkr):
         """
         k8s_files_path = self.kard.path / 'k8s'
 
+        old_cm = self.get_configmap()
+        new_cm = {}
+
+        write("Compare with previous deployment ...")
         for k8s_file in sorted(k8s_files_path.glob('*.yml')):
-            write('Processing {}'.format(k8s_file))
+            if services and k8s_file.name[:-4] not in services:
+                continue
+
+            if k8s_file.name in old_cm:
+                with NamedTemporaryFile() as f:
+                    f.write(old_cm[k8s_file.name].encode('utf-8'))
+                    f.seek(0)
+                    self.run_cmd('diff -u {} {}'.format(f.name, k8s_file))
+            else:
+                write("Added file {}".format(k8s_file))
+
+            with open(str(k8s_file), 'r') as f:
+                new_cm[k8s_file.name] = f.read()
+
+        for name in old_cm:
+            if name not in new_cm:
+                write("Removed file {}".format(name))
+
+        if sys.stdin.isatty():
+            proceed = None
+            while proceed not in {"y", "n"}:
+                proceed = input("Apply (y/n) ? ")
+            if proceed == "n":
+                return
+
+        write("\nApplying manifests ...")
+        for k8s_file in sorted(k8s_files_path.glob('*.yml')):
+            if services and k8s_file.name[:-4] not in services:
+                continue
+            write('Processing {}'.format(k8s_file.name))
             out, _ = self.run_kubectl('apply -f {}'.format(k8s_file))
             write(out)
-            sleep(0.5)
+            sleep(0.1)
+
+        for name in old_cm:
+            if name not in new_cm:
+                write("Removing {}".format(name))
+                with NamedTemporaryFile() as f:
+                    f.write(old_cm[name].encode('utf-8'))
+                    f.seek(0)
+                    out, _ = self.run_kubectl('delete -f {}'.format(f.name))
+                    write(out)
+
+        self.write_configmap(new_cm)
 
     def stop(self, services=None):
         """Stops services"""
         k8s_files_path = self.kard.path / 'k8s'
 
         for k8s_file in sorted(k8s_files_path.glob('*.yml'), reverse=True):
+            if services and k8s_file.name[:-4] not in services:
+                continue
             write('Processing {}'.format(k8s_file))
             out, _ = self.run_kubectl('delete -f {}'.format(k8s_file))
             write(out)
@@ -147,5 +251,7 @@ class KubernetesPkr(Pkr):
         response = self.client.list_namespaced_pod(self.namespace)
         services = response.items
         for service in services:
-            write(' - {}: {}'.format(
-                service.metadata.name, service.status.pod_ip))
+            write(' - {}: {} - {}'.format(
+                service.metadata.name,
+                service.status.phase,
+                service.status.pod_ip))


### PR DESCRIPTION
Use configmap to store previous deployment. 

Enabled use cases:
  - Add a "diff" phase with confirmation in start command.
  - Allow a smooth handling when removing ressources (by file, see below)

Caveat :
  - would be better to process content of input files, to be able to delete resources 1 by 1, but for now showing the diff should be enough, cleaning independent kube resources (removed from input files) manually