### PR TITLE
Predictive file import

### DIFF
--- a/pkr/utils.py
+++ b/pkr/utils.py
@@ -104,7 +104,7 @@ def merge(source, destination):
         elif isinstance(value, list):
             if key in destination:
                 try:
-                    destination[key] = list(set(destination[key] + value))
+                    destination[key] = list(dict.fromkeys(destination[key] + value))
                 # Prevent errors when having unhashable dict types
                 except TypeError:
                     destination[key].extend(value)


### PR DESCRIPTION
Merge with a set does not provide predictive order, thus default_features is not predictive.
This leads to a compose file (or any other sensitive files) to be different with same env/meta.

With compose, it is forcing containers to be restarted, which sometimes break deploy.