### PR TITLE
up: remove matching compose services to images names

### DIFF
--- a/pkr/cli/parser.py
+++ b/pkr/cli/parser.py
@@ -165,7 +165,6 @@ def get_parser():
     # Up parser
     up_parser = sub_p.add_parser(
         'up', help='Rebuild context, images and start pkr')
-    add_service_argument(up_parser)
     up_parser.add_argument(
         '-v',
         '--verbose',
@@ -180,7 +179,7 @@ def get_parser():
 
     up_parser.set_defaults(
         func=lambda a: Kard.load_current().docker_cli.cmd_up(
-            a.services, verbose=a.verbose, build_log=a.build_log))
+            verbose=a.verbose, build_log=a.build_log))
 
     # Ps parser
     parser = sub_p.add_parser(

--- a/pkr/driver/docker_compose.py
+++ b/pkr/driver/docker_compose.py
@@ -169,25 +169,10 @@ class ComposePkr(Pkr):
         # Remove unexisting services
         return set(services) & set(all_services)
 
-    def build_images(
-        self, services, tag=None, verbose=True, logfile=None, nocache=False,
-        parallel=None
-    ):
-
-        def req_build(container):
-            """Return True if the container requires being built"""
-            try:
-                return 'dockerfile' in self.kard.env.get_container(container)
-            except KeyError:
-                return False
-
-        super(ComposePkr, self).build_images(
-            [s for s in services if req_build(s)], tag, verbose, logfile, nocache, parallel)
-
     def start(self, services=None, yes=False):
         self._call_compose('up', '-d', *(services or ()))
 
-    def cmd_up(self, services=None, verbose=False, build_log=None):
+    def cmd_up(self, verbose=False, build_log=None):
         """Start PCLM in a the docker environement.
 
         Use parameters stored in meta.yml to generate the
@@ -198,21 +183,20 @@ class ComposePkr(Pkr):
         containers that need to communicate with bare metal machines on
         the given network.
         """
-
         # Re-populating the context...
         self.kard.make()
 
-        eff_modules = self._resolve_services(services)
+        services = list(self.kard.env.get_container().keys())
+        self.build_images(services, verbose=verbose, logfile=build_log)
 
-        self.build_images(eff_modules, verbose=verbose, logfile=build_log)
-
-        self.start(services)
+        self.start()
 
         # Do a nap while the containers are launching before calling
         # post_compose
         time.sleep(5)
 
         # Call post run handlers on extensions
+        eff_modules = self._resolve_services()
         self.kard.extensions.post_up(eff_modules)
 
     def stop(self, services=None):


### PR DESCRIPTION
We try to leverage common image for 2 services, but command up is not compatible with this behavior.

Choice made here is to avoid parsing compose file.