### PR TITLE
Allow --extra flag to be used more than once

### DIFF
--- a/pkr/cli/action.py
+++ b/pkr/cli/action.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+# Copyright© 1986-2018 Altair Engineering Inc
+
+from argparse import Action, OPTIONAL
+import copy
+
+
+class ExtendAction(Action):
+    """CLI argument extend action"""
+
+    def __init__(
+        self,
+        option_strings,
+        dest,
+        nargs=None,
+        const=None,
+        default=None,
+        type=None,
+        choices=None,
+        required=False,
+        help=None,
+        metavar=None,
+    ):
+        if nargs == 0:
+            raise ValueError(
+                "nargs for append actions must be != 0; if arg string are not "
+                "supplying the value to append, the append const action may "
+                "be more appropriate"
+            )
+        if const is not None and nargs != OPTIONAL:
+            raise ValueError("nargs must be %r to supply const" % OPTIONAL)
+
+        super(ExtendAction, self).__init__(
+            option_strings=option_strings,
+            dest=dest,
+            nargs=nargs,
+            const=const,
+            default=default,
+            type=type,
+            choices=choices,
+            required=required,
+            help=help,
+            metavar=metavar,
+        )
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        items = getattr(namespace, self.dest, None)
+
+        if items is None:
+            items = []
+        elif isinstance(items, list):
+            items = items[:]
+        else:
+            items = copy.copy(items)
+
+        items.extend(values)
+        setattr(namespace, self.dest, items)

--- a/pkr/cli/parser.py
+++ b/pkr/cli/parser.py
@@ -336,7 +336,9 @@ def configure_kard_parser(parser):
         help='Do not change the "current" symbolic link after creating the Kard.',
         action="store_true",
     )
-    create_kard_p.add_argument("--extra", nargs="*", default=[], help="Extra args")
+    create_kard_p.add_argument(
+        "--extra", nargs="*", default=[], action="extend", help="Extra args",
+    )
 
     list_kard = sub_p.add_parser("list", help="List kards")
     list_kard.add_argument(

--- a/pkr/cli/parser.py
+++ b/pkr/cli/parser.py
@@ -9,6 +9,7 @@ import argparse
 from pathlib import Path
 import yaml
 
+from .action import ExtendAction
 from .log import write
 from ..driver import list_drivers
 from ..ext import ExtMixin, Extensions
@@ -337,7 +338,11 @@ def configure_kard_parser(parser):
         action="store_true",
     )
     create_kard_p.add_argument(
-        "--extra", nargs="*", default=[], action="extend", help="Extra args",
+        "--extra",
+        nargs="*",
+        default=[],
+        action=ExtendAction,
+        help="Extra args",
     )
 
     list_kard = sub_p.add_parser("list", help="List kards")

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -125,7 +125,7 @@ class TestCLI(pkrTestCase):
         self.assertEqual(msg, stdout)
 
     def test_kard_create_with_extra(self):
-        cmd = "{} kard create test --extra tag=123".format(self.PKR)
+        cmd = "{} kard create test --extra tag=123 --extra tag2=456".format(self.PKR)
 
         prc = self._run_cmd(cmd)
         stdout = prc.stdout.read()
@@ -150,6 +150,7 @@ class TestCLI(pkrTestCase):
             "features": [],
             "project_name": "test",
             "tag": "123",
+            "tag2": "456",
         }
 
         self.assertEqual(expected_meta, yaml.safe_load(meta_file.open("r")))


### PR DESCRIPTION
This PR fixes some slightly confusing behavior with the `--extra` flag. Presently, if the flag is provided more than once, only the last value is used. For example, this results in only `key3: value3` being added to the `meta.yml` file:
```
pkr kard create <other-args> --extra key1=value1 key2=value2 --extra key3=value3
```
After this change, all of the provided extra data will be added.

There is an `extend` action for CLI arguments which was added to `argparse` in Python 3.8 which provides the desired behavior. I have copied its functionality into the `pkr.cli.action` module for Python 3.7 compatibility.