### PR TITLE
Compose ignore not started services for status

### DIFF
--- a/pkr/version.py
+++ b/pkr/version.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 # Copyright© 1986-2022 Altair Engineering Inc.
 
-__version__ = "1.4.21"
+__version__ = "1.4.22"


### PR DESCRIPTION
This PR modify the stack status computation to ignore the services that had not been started by the "docker-compose up" command.