### PR TITLE
Refine template globbing

### DIFF
--- a/pkr/driver/docker.py
+++ b/pkr/driver/docker.py
@@ -102,7 +102,18 @@ class DockerDriver(AbstractDriver):
             dockerfile = Path(dockerfile).stem
             templates.append(
                 {
-                    "source": templates_path / f"{dockerfile}*",  # Match template
+                    "source": templates_path / f"{dockerfile}",  # Match template
+                    "origin": templates_path,
+                    "destination": "",
+                    "subfolder": context,
+                }
+            )
+
+            # Also add anything matching dockerfile name stem with an extension
+            # suffix of some kind
+            templates.append(
+                {
+                    "source": templates_path / f"{dockerfile}.*",  # Match template
                     "origin": templates_path,
                     "destination": "",
                     "subfolder": context,

--- a/pkr/utils.py
+++ b/pkr/utils.py
@@ -294,7 +294,7 @@ class TemplateEngine(object):
                 # os.chmod(str(dst_path), 0o600) # make invisible to the world
             else:
                 shutil.copy2(path_str, str(dst_path))
-        else:
+        elif path.is_dir():
             for path_it in path.iterdir():
                 path_it = path / path_it
                 if not any([fnmatch(str(path_it), str(exc_path)) for exc_path in excluded_paths]):

--- a/pkr/version.py
+++ b/pkr/version.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 # Copyright© 1986-2022 Altair Engineering Inc.
 
-__version__ = "1.4.26"
+__version__ = "1.4.27"


### PR DESCRIPTION
Resolves issue with Dockerfile names starting with same prefix (ex: service1, service1-logger) resulting in templates being duplicated in wrong context.