### PR TITLE
fix: Propagate exit code of failed docker compose commands

### DIFF
--- a/pkr/driver/docker_compose.py
+++ b/pkr/driver/docker_compose.py
@@ -77,7 +77,12 @@ class ComposePkr:
 
         debug(f"driver: _call_compose: cmd={compose_cmd}")
         compose = self._get_compose_data()
-        return subprocess.run(compose_cmd, input=compose, check=False)
+        try:
+            return subprocess.run(compose_cmd, input=compose, check=True)
+        except subprocess.CalledProcessError as exc:
+            raise PkrException(
+                f"Subcommand {compose_cmd} returned non-zero exit code: {exc.returncode}"
+            ) from exc
 
     def _get_compose_data(self):
         if self.compose_file.exists():


### PR DESCRIPTION
Pkr was not checking the output of any docker compose subcommands, which could cause some operations to silently fail. Changed to exit pkr with the same exit code as docker compose exits with.

Noticed during `pkr clean` which could fail if there was a missing environment variable due to docker compose interpolation, causing the clean command to fail.

https://docs.docker.com/compose/how-tos/environment-variables/variable-interpolation/#interpolation-syntax