### PR TITLE
fix: Allow empty docker compose files to be merged

### DIFF
--- a/pkr/driver/docker_compose.py
+++ b/pkr/driver/docker_compose.py
@@ -130,7 +130,9 @@ class ComposePkr:
         compose_path = self.kard.path / "compose"
         for file in compose_path.iterdir():
             # Merge the compose_file
-            merge(yaml.safe_load(file.open("r")), merged_compose)
+            yaml_data = yaml.safe_load(file.open("r"))
+            if yaml_data is not None:
+                merge(yaml_data, merged_compose)
 
         if meta_txt:
             with self.compose_file.open("w") as dcf:

--- a/test/files/path2/env/common/env.yml
+++ b/test/files/path2/env/common/env.yml
@@ -10,3 +10,5 @@ default_meta:
   driver:
     docker_compose:
       compose_file: 'templates/docker-compose.yml.template'
+      compose_extension_files:
+        - templates/empty.yml.template

--- a/test/test_environment.py
+++ b/test/test_environment.py
@@ -28,7 +28,12 @@ class TestEnvironment(unittest.TestCase):
             "default_meta": {
                 "from": "env",
                 "driver": {
-                    "docker_compose": {"compose_file": "templates/docker-compose.yml.template"}
+                    "docker_compose": {
+                        "compose_file": "templates/docker-compose.yml.template",
+                        "compose_extension_files": [
+                            "templates/empty.yml.template",
+                        ],
+                    }
                 },
             },
             "import": ["common/env"],
@@ -47,7 +52,12 @@ class TestEnvironment(unittest.TestCase):
             "default_features": ["auto-volume"],
             "default_meta": {
                 "driver": {
-                    "docker_compose": {"compose_file": "templates/docker-compose.yml.template"},
+                    "docker_compose": {
+                        "compose_file": "templates/docker-compose.yml.template",
+                        "compose_extension_files": [
+                            "templates/empty.yml.template",
+                        ],
+                    },
                     "k8s": {"k8s_files": ["templates/k8s.yml.template"]},
                     "name": "k8s",
                 },
@@ -68,7 +78,12 @@ class TestEnvironment(unittest.TestCase):
             "default_features": ["auto-volume"],
             "default_meta": {
                 "driver": {
-                    "docker_compose": {"compose_file": "templates/docker-compose.yml.template"}
+                    "docker_compose": {
+                        "compose_file": "templates/docker-compose.yml.template",
+                        "compose_extension_files": [
+                            "templates/empty.yml.template",
+                        ],
+                    },
                 },
                 "from": "import",
             },
@@ -92,7 +107,12 @@ class TestEnvironment(unittest.TestCase):
 
         expected_values = {
             "driver": {
-                "docker_compose": {"compose_file": "templates/docker-compose.yml.template"}
+                "docker_compose": {
+                    "compose_file": "templates/docker-compose.yml.template",
+                    "compose_extension_files": [
+                        "templates/empty.yml.template",
+                    ],
+                }
             },
             "features": ["auto-volume"],
             "from": "import",


### PR DESCRIPTION
Without this, attempting to merge an empty docker compose yaml file would cause an error trying to iterate on a NoneType.

An empty docker compose file can happen when attempting to include a compose extension file with a templated body.