### PR TITLE
chore: remove unnecessary dependency on netifaces

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -112,7 +112,7 @@ ignored-classes=
 # List of members which are set dynamically and missed by pylint inference
 # system, and so shouldn't trigger E1101 when accessed. Python regular
 # expressions are accepted.
-generated-members=netifaces.ifaddresses,netifaces.interfaces
+generated-members=
 
 
 [LOGGING]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ dependencies = [
     "jinja2",
     "jinja2-ansible-filters==1.3.2",
     "kubernetes>=25.0.0",
-    "netifaces==0.11.0",
     "passlib>=1.7.1",
     "pybase64==1.3.2",
     "pycryptodome==3.19.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,6 @@ jinja2==3.1.5
 jinja2-ansible-filters==1.3.2
 kubernetes==29.0.0
 markupsafe==2.1.2
-netifaces==0.11.0
 oauthlib==3.2.2
 passlib==1.7.4
 pyasn1==0.4.8


### PR DESCRIPTION
netifaces package is outdated and hasn't been maintained for 4 years. It doesn't seem to be used by pkr anyway. Pkr docker image fails to build with later versions of apline docker images as a base due to netifaces dependency.