### PR TITLE
Fix merge behavior for None values

### DIFF
--- a/pkr/utils.py
+++ b/pkr/utils.py
@@ -111,6 +111,10 @@ def merge(source, destination, overwrite=True):
     Warning: the source dict is merged INTO the destination one. Make a copy
     before using it if you do not want to destroy the destination dict.
     """
+    if not source:
+        return destination
+    if destination is None:
+        destination = {}
     for key, value in list(source.items()):
         if isinstance(value, dict):
             # Handle type mismatch

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,0 +1,56 @@
+# Copyright© 1986-2024 Altair Engineering Inc.
+
+import unittest
+from pkr.utils import merge
+
+
+class TestMerge(unittest.TestCase):
+    """
+    TestMerge tests the behavior of the merge function in pkr/utils.py.
+
+    The current test set does not cover all possible behaviors of the merge
+    function.
+    """
+
+    def test_none_source(self):
+        source = None
+        dest = {"key": "value"}
+        result = merge(source, dest)
+        self.assertEqual(result, dest)
+        self.assertIsNone(source)
+
+    def test_empty_source(self):
+        source = {}
+        dest = {"key": "value"}
+        result = merge(source, dest)
+        self.assertEqual(result, dest)
+
+    def test_none_destination(self):
+        source = {"key": "value"}
+        dest = None
+        result = merge(source, dest)
+        self.assertEqual(result, source)
+        self.assertIsNone(dest)
+
+    def test_empty_destination(self):
+        source = {"key": "value"}
+        dest = {}
+        result = merge(source, dest)
+        self.assertEqual(result, source)
+
+        # Mutate result, should also change dest
+        result["test"] = 12
+        self.assertIn("test", dest)
+        self.assertEqual(dest["test"], 12)
+
+    def test_simple_merge(self):
+        source = {"key1": "value", "key2": "new value"}
+        dest = {"key2": "old value", "key3": 9}
+        result = merge(source, dest)
+
+        # Result should include all unique keys and any duplicates should
+        # have the value from source.
+        self.assertEqual(
+            result,
+            {"key1": "value", "key2": "new value", "key3": 9},
+        )

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ whitelist_externals =
   /usr/bin/bash
 deps = .
 extras = dev
-commands = pytest test --junit-xml pkr-test-report-{envname}.xml --junit-prefix {envname} {posargs}
+commands = pytest --junit-xml pkr-test-report-{envname}.xml --junit-prefix {envname} {posargs}
 
 [testenv:format]
 deps = pylint==3.0.3


### PR DESCRIPTION
Fixes the behavior of the `merge` function in `pkr/utils.py` for cases where the `source` is `None`. This issue in the general code path of the application was resolved in #161 by checking the input to `merge`, but this PR fixes it at the function level, which feels simpler than requiring the caller to validate the input.

Additional changes include adding tests for `merge` and making a tweak to the `pytest` invocation to allow specifying individual test files or cases.