### PR TITLE
Allow skipping image pulls

### DIFF
--- a/pkr/driver/docker.py
+++ b/pkr/driver/docker.py
@@ -592,7 +592,13 @@ class DockerDriver(AbstractDriver):
         rep_tag = f"{registry_url}/{image_name}"
 
         try:
-            self.docker.pull(repository=rep_tag, tag=remote_tag)
+            # Check whether we already have the image locally, using the full
+            # image name (repo/image:tag format). Don't pull try to pull images
+            # if we already have them because it can take a non-negligible
+            # amount of time.
+            full_image_name = self.make_image_name(rep_tag, tag=remote_tag)
+            if len(self.docker.images(full_image_name)) != 1:
+                self.docker.pull(repository=rep_tag, tag=remote_tag)
 
             # Strip the repository tag
             self.docker.tag(


### PR DESCRIPTION
* Add ability to skip image pulls when the image is already available locally. This saves ~1.5-2 seconds per image, which can add up when you have several images from remote repos.
* Make logic more clear for deciding when to skip image rebuilds.
* Add `--no-rebuild` flag to `pkr up` command to allow skipping image rebuilds (may be desirable in cases like running Robot Framework test suites; for example, if you just change the tests, there isn't a need to rebuild the image)